### PR TITLE
chore: use increase-if-necessary dependabot versioning strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    versioning-strategy: increase-if-necessary
     commit-message:
       prefix: "patch"
       prefix-development: "dev-patch"


### PR DESCRIPTION
forces dependabot to update the package.json file if it detects that the version does not match the new version of the package. See [versioning strategy](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy)