### PR TITLE
Fix SVGO config setup

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,28 +1,12 @@
 const { optimize } = require('svgo');
 const { version } = require('vue');
 const semverMajor = require('semver/functions/major')
-
-const defaultConfig = {
-  plugins: [
-    {
-      name: 'preset-default',
-      params: {
-        overrides: {
-          inlineStyles: {
-            //force deletion of <style> tags in order for vue-loader to accept the template (no nested tags with side effects allowed)
-            onlyMatchedOnce: false
-          }
-        }
-      }
-    }
-  ]
-}
+const sanitizeSvgoConfig = require('./svgoConfigBuilder')
 
 module.exports = function vueSvgLoader(svg) {
   let { svgo: svgoConfig } = this.getOptions() || {};
 
-  // merge svgoConfig with defaultConfig in order to force inlining <style> tags
-  svgoConfig = {...svgoConfig, ...defaultConfig};
+  svgoConfig = sanitizeSvgoConfig(svgoConfig);
 
   let optimized;
   optimized = optimize(svg, {

--- a/svgoConfigBuilder.js
+++ b/svgoConfigBuilder.js
@@ -1,15 +1,3 @@
-const defaultConfig = {
-  name: 'preset-default',
-  params: {
-    overrides: {
-      inlineStyles: {
-        //force deletion of <style> tags in order for vue-loader to accept the template (no nested tags with side effects allowed)
-        onlyMatchedOnce: false
-      }
-    }
-  }
-}
-
 module.exports = function sanitizeSvgoConfig(svgoConfig) {
   const newConfig = JSON.parse(JSON.stringify(svgoConfig || {}));
   let plugins = newConfig.plugins = newConfig.plugins || [];

--- a/svgoConfigBuilder.js
+++ b/svgoConfigBuilder.js
@@ -1,0 +1,29 @@
+const defaultConfig = {
+  name: 'preset-default',
+  params: {
+    overrides: {
+      inlineStyles: {
+        //force deletion of <style> tags in order for vue-loader to accept the template (no nested tags with side effects allowed)
+        onlyMatchedOnce: false
+      }
+    }
+  }
+}
+
+module.exports = function sanitizeSvgoConfig(svgoConfig) {
+  const newConfig = JSON.parse(JSON.stringify(svgoConfig || {}));
+  let plugins = newConfig.plugins = newConfig.plugins || [];
+  let defaultPreset = plugins.find(plugin => plugin.name === 'preset-default');
+
+  if(!defaultPreset) {
+    const preset = {name: 'preset-default'}
+    plugins.push(preset);
+    defaultPreset = preset;
+  }
+
+  const params = defaultPreset.params = defaultPreset.params || {}
+  const overrides = params.overrides = params.overrides || {}
+  const inlineStyles = overrides.inlineStyles = overrides.inlineStyles || {}
+  inlineStyles.onlyMatchedOnce = false;
+  return newConfig;
+}

--- a/test/configBuilder.test.js
+++ b/test/configBuilder.test.js
@@ -1,0 +1,46 @@
+const sanitizeSvgoConfig = require('../svgoConfigBuilder');
+
+const config = {
+  plugins: [
+    {
+      name: 'preset-default',
+      params: {
+        overrides: {
+          inlineStyles: {
+            //force deletion of <style> tags in order for vue-loader to accept the template (no nested tags with side effects allowed)
+            onlyMatchedOnce: false
+          }
+        }
+      }
+    }
+  ]
+}
+
+const copy = obj => JSON.parse(JSON.stringify(obj));
+
+it('should produce a valid svgo config', () => {
+  expect(sanitizeSvgoConfig({})).toEqual(config);
+});
+
+it('should not change a valid svgo config', () => {
+  expect(sanitizeSvgoConfig(config)).toEqual(config);
+});
+
+it('should override onlymatchedonce to false', () => {
+  const test = copy(config);
+  test.plugins[0].params.overrides.inlineStyles.onlyMatchedOnce = false;
+  expect(sanitizeSvgoConfig(test)).toEqual(config);
+});
+
+it('should keep unrelated information unchanged', () => {
+  const test = copy(config);
+  test.plugins[0].params.overrides.inlineStyles.onlyMatchedOnce = true;
+  test.plugins.push({name: "foobar", params: {foo: "bar", ...copy(config.plugins[0].params)}})
+  const expectation = copy(test);
+  expectation.plugins[0].params.overrides.inlineStyles.onlyMatchedOnce = false;
+  expect(sanitizeSvgoConfig(test)).toEqual(expectation);
+});
+
+it('should create a new config from a passed svgoConfig', () => {
+  expect(sanitizeSvgoConfig(config)).not.toBe(config);
+});

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -5,7 +5,26 @@ import compiler from './compiler.js';
 const fs = require('fs');
 import path from 'path';
 import vueSvgLoader from '../index.js';
+const sanitizeSvgoConfig = require('../svgoConfigBuilder.js');
 const semVerMajor = require('semver/functions/major');
+
+const config = {
+  plugins: [
+    {
+      name: 'preset-default',
+      params: {
+        overrides: {
+          inlineStyles: {
+            //force deletion of <style> tags in order for vue-loader to accept the template (no nested tags with side effects allowed)
+            onlyMatchedOnce: false
+          }
+        }
+      }
+    }
+  ]
+}
+
+const copy = obj => JSON.parse(JSON.stringify(obj));
 
 function getActualTemplate(stats){
   let source = stats.toJson({source: true}).modules[0].source; //get the compilation result
@@ -61,3 +80,30 @@ it('injects listeners for Vue 2', async () => {
   vueTemplate = vueSvgLoader.call(context, file);
   expect(vueTemplate).not.toContain('v-on="$listeners"');
 })
+
+it('should produce a valid svgo config', () => {
+  expect(sanitizeSvgoConfig({})).toEqual(config);
+});
+
+it('should not change a valid svgo config', () => {
+  expect(sanitizeSvgoConfig(config)).toEqual(config);
+});
+
+it('should override onlymatchedonce to false', () => {
+  const test = copy(config);
+  test.plugins[0].params.overrides.inlineStyles.onlyMatchedOnce = false;
+  expect(sanitizeSvgoConfig(test)).toEqual(config);
+});
+
+it('should keep unrelated information unchanged', () => {
+  const test = copy(config);
+  test.plugins[0].params.overrides.inlineStyles.onlyMatchedOnce = true;
+  test.plugins.push({name: "foobar", params: {foo: "bar", ...copy(config.plugins[0].params)}})
+  const expectation = copy(test);
+  expectation.plugins[0].params.overrides.inlineStyles.onlyMatchedOnce = false;
+  expect(sanitizeSvgoConfig(test)).toEqual(expectation);
+});
+
+it('should create a new config from a passed svgoConfig', () => {
+  expect(sanitizeSvgoConfig(config)).not.toBe(config);
+});

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -5,26 +5,7 @@ import compiler from './compiler.js';
 const fs = require('fs');
 import path from 'path';
 import vueSvgLoader from '../index.js';
-const sanitizeSvgoConfig = require('../svgoConfigBuilder.js');
 const semVerMajor = require('semver/functions/major');
-
-const config = {
-  plugins: [
-    {
-      name: 'preset-default',
-      params: {
-        overrides: {
-          inlineStyles: {
-            //force deletion of <style> tags in order for vue-loader to accept the template (no nested tags with side effects allowed)
-            onlyMatchedOnce: false
-          }
-        }
-      }
-    }
-  ]
-}
-
-const copy = obj => JSON.parse(JSON.stringify(obj));
 
 function getActualTemplate(stats){
   let source = stats.toJson({source: true}).modules[0].source; //get the compilation result
@@ -80,30 +61,3 @@ it('injects listeners for Vue 2', async () => {
   vueTemplate = vueSvgLoader.call(context, file);
   expect(vueTemplate).not.toContain('v-on="$listeners"');
 })
-
-it('should produce a valid svgo config', () => {
-  expect(sanitizeSvgoConfig({})).toEqual(config);
-});
-
-it('should not change a valid svgo config', () => {
-  expect(sanitizeSvgoConfig(config)).toEqual(config);
-});
-
-it('should override onlymatchedonce to false', () => {
-  const test = copy(config);
-  test.plugins[0].params.overrides.inlineStyles.onlyMatchedOnce = false;
-  expect(sanitizeSvgoConfig(test)).toEqual(config);
-});
-
-it('should keep unrelated information unchanged', () => {
-  const test = copy(config);
-  test.plugins[0].params.overrides.inlineStyles.onlyMatchedOnce = true;
-  test.plugins.push({name: "foobar", params: {foo: "bar", ...copy(config.plugins[0].params)}})
-  const expectation = copy(test);
-  expectation.plugins[0].params.overrides.inlineStyles.onlyMatchedOnce = false;
-  expect(sanitizeSvgoConfig(test)).toEqual(expectation);
-});
-
-it('should create a new config from a passed svgoConfig', () => {
-  expect(sanitizeSvgoConfig(config)).not.toBe(config);
-});


### PR DESCRIPTION
correctly builds a valid SVGO config from the `svgo` config passed via webpack options. This fixes #45 and #25.